### PR TITLE
fix: don't normalize additional arguments in vr command

### DIFF
--- a/cli_test.ts
+++ b/cli_test.ts
@@ -9,9 +9,13 @@ const cliArgs = [
 ];
 const expectedOutput = "Works!";
 
-async function runScript(name: string, wd: string = yamlWd): Promise<string> {
+async function runScript(
+  name: string,
+  wd: string = yamlWd,
+  additionalArgs: Array<string> = [],
+): Promise<string> {
   const process = Deno.run({
-    cmd: [...cliArgs, name],
+    cmd: [...cliArgs, name, ...additionalArgs],
     cwd: wd,
     stdout: "piped",
   });
@@ -85,4 +89,12 @@ Deno.test("importmap", async () => {
 Deno.test("--help", async () => {
   const output = await runScript("--help");
   assertStringIncludes(output, "--version");
+});
+
+Deno.test("forward arguments", async () => {
+  const output = await runScript("forward", yamlWd, ["--shuffle=1234"]);
+  assertStringIncludes(
+    output.replace(/\r\n|\r|\n/g, " "),
+    "deno test --lock=lock.json --cached-only --shuffle=1234",
+  );
 });

--- a/deps.ts
+++ b/deps.ts
@@ -20,7 +20,7 @@ export {
   CompletionsCommand,
   StringType,
   ValidationError,
-} from "https://deno.land/x/cliffy@v0.19.1/command/mod.ts";
+} from "https://deno.land/x/cliffy@v0.19.3/command/mod.ts";
 export { kill } from "https://deno.land/x/process@v0.3.0/mod.ts";
 export {
   DenoLand,

--- a/test/yaml/scripts.yml
+++ b/test/yaml/scripts.yml
@@ -26,3 +26,5 @@ scripts:
   importmap:
     cmd: deno run --unstable imap.ts
     imap: importmap.json
+  forward:
+    cmd: echo deno test --lock=lock.json --cached-only


### PR DESCRIPTION
closes: #70

- update cliffy to v0.19.3 to fix the bug
- add test for forwarding options