### PR TITLE
feat: support desc field for concurrent scripts & Deno v1.13.x compatibility

### DIFF
--- a/src/build_command_string.ts
+++ b/src/build_command_string.ts
@@ -19,6 +19,7 @@ enum DenoOptions {
   unstable = "unstable",
   v8Flags = "v8Flags",
   watch = "watch",
+  shuffle = "shuffle",
 }
 
 const denoCmdOptions: { [key: string]: DenoOptions[] } = {
@@ -85,6 +86,7 @@ const denoCmdOptions: { [key: string]: DenoOptions[] } = {
     DenoOptions.tsconfig,
     DenoOptions.unstable,
     DenoOptions.v8Flags,
+    DenoOptions.shuffle,
   ],
   cache: [
     DenoOptions.cert,

--- a/src/scripts_config.ts
+++ b/src/scripts_config.ts
@@ -60,6 +60,12 @@ export type CompositeScript = ParallelScripts | Array<Script | ParallelScripts>;
  */
 export interface ParallelScripts {
   /**
+   * A textual description of what this set of scripts do.
+   * This will be shown in the list of available scripts,
+   * when calling `vr` without arguments.
+   */
+  desc?: string;
+  /**
    * The list of script to be executed in parallel
    */
   pll: Script[];

--- a/src/scripts_config.ts
+++ b/src/scripts_config.ts
@@ -205,7 +205,7 @@ export interface AllowFlags {
   env?: boolean;
   hrtime?: boolean;
   net?: string | boolean;
-  plugin?: boolean;
+  ffi?: boolean;
   read?: string | boolean;
   run?: boolean;
   write?: string | boolean;

--- a/src/scripts_info.ts
+++ b/src/scripts_info.ts
@@ -45,6 +45,8 @@ function scriptInfo(script: ScriptDefinition): string {
       return s.desc;
     }).filter(Boolean);
     info.push(`${indent}${combinedDescriptions.join(", ")}`);
+  } else if (isParallelScripts(script)) {
+    if (script.desc) info.push(`${indent}${script.desc}`);
   }
   const commands = flattenCommands(normalizeScript(script, {}));
   info.push(

--- a/src/scripts_info.ts
+++ b/src/scripts_info.ts
@@ -5,7 +5,11 @@ import {
   ScriptsConfiguration,
 } from "./scripts_config.ts";
 import { flattenCommands, normalizeScript } from "./normalize_script.ts";
-import { isMultiCompositeScript, isScriptObject } from "./util.ts";
+import {
+  isMultiCompositeScript,
+  isParallelScripts,
+  isScriptObject,
+} from "./util.ts";
 
 export function printScriptsInfo(config: ScriptsConfiguration) {
   const scripts = Object.entries(config.scripts);


### PR DESCRIPTION
This PR adds support for the `desc` field for [concurrent scripts](https://velociraptor.run/docs/composite-scripts/#concurrent-scripts).

This PR also adds support for Deno 1.13.x.