### PR TITLE
feat: add `.js` and `.mjs` support to config loader

### DIFF
--- a/src/load_config.ts
+++ b/src/load_config.ts
@@ -2,7 +2,9 @@ import { existsSync, parseYaml, path } from "../deps.ts";
 import { ScriptsConfiguration } from "./scripts_config.ts";
 
 const CONFIG_FILE_NAMES = ["scripts", "velociraptor"];
-const CONFIG_FILE_EXTENSIONS = ["yaml", "yml", "json", "ts"];
+const STATIC_CONFIG_FILE_EXTENSIONS = ["yaml", "yml", "json"];
+const DYNAMIC_CONFIG_FILE_EXTENSIONS = ["ts", "js", "mjs"];
+const CONFIG_FILE_EXTENSIONS = [...STATIC_CONFIG_FILE_EXTENSIONS, ...DYNAMIC_CONFIG_FILE_EXTENSIONS];
 
 export interface ConfigData {
   cwd: string;
@@ -18,7 +20,7 @@ export async function loadConfig(): Promise<ConfigData | null> {
         if (existsSync(p)) {
           return {
             cwd: dir,
-            config: await parseConfig(p, ext == "ts"),
+            config: await parseConfig(p, DYNAMIC_CONFIG_FILE_EXTENSIONS.includes(ext)),
           };
         }
       }
@@ -34,9 +36,9 @@ function parent(dir: string) {
 
 async function parseConfig(
   configPath: string,
-  isTypescript: boolean,
+  isDynamic: boolean,
 ): Promise<ScriptsConfiguration> {
-  if (isTypescript) {
+  if (isDynamic) {
     return (await import(`file://${configPath}`))
       .default as ScriptsConfiguration;
   }


### PR DESCRIPTION
Feature requested here: https://github.com/jurassiscripts/velociraptor/discussions/96

I renamed the argument `isTypescript` to `isDynamic` to better reflect it's new purpose. The behaviour of the async import below that shouldn't change. I split `CONFIG_FILE_EXTENSIONS` into two, `STATIC_CONFIG_FILE_EXTENSIONS` and `DYNAMIC_CONFIG_FILE_EXTENSIONS`, solely to avoid the previously hard-coded `ext == "ts"`, which would've been a hard-coded `["ts", "js", "mjs"].includes(ext)` otherwise.

I didn't add tests for this because the `.json` and `.yml` file extension is missing in the tests as well. However I will later create an additional PR based on this branch, which implements tests for all the extensions.