### PR TITLE
feat: support `deno task`

### DIFF
--- a/cli_test.ts
+++ b/cli_test.ts
@@ -2,6 +2,7 @@ import { assertEquals, assertMatch, assertStringIncludes } from "./dev_deps.ts";
 const yamlWd = "./test/yaml";
 const tsWd = "./test/ts";
 const jsonWd = "./test/json";
+const taskWd = "./test/task";
 const cliArgs = [
   "deno",
   "run",
@@ -47,8 +48,13 @@ Deno.test("ts config file", async () => {
   assertStringIncludes(output, expectedOutput);
 });
 
-Deno.test("deno.json(c) config file", async () => {
+Deno.test("deno.json(c) config file with `velociraptor` field", async () => {
   const output = await runScript("test", jsonWd);
+  assertStringIncludes(output, expectedOutput);
+});
+
+Deno.test("deno.json(c) config file with `task` field", async () => {
+  const output = await runScript("test", taskWd);
   assertStringIncludes(output, expectedOutput);
 });
 

--- a/src/load_config.ts
+++ b/src/load_config.ts
@@ -68,6 +68,6 @@ async function parseDenoConfig(
       (m, g) => g ? "" : m,
     );
   }
-  const { velociraptor: config = {} } = JSON.parse(content);
-  return config as ScriptsConfiguration;
+  const { velociraptor, tasks } = JSON.parse(content);
+  return (velociraptor || (tasks ? { scripts: tasks } : {})) as ScriptsConfiguration;
 }

--- a/test/task/deno.jsonc
+++ b/test/task/deno.jsonc
@@ -1,0 +1,14 @@
+{
+    // Used to test that --config option is working properly
+    "lint": {
+        "rules": {
+          "exclude": ["no-explicit-any"]
+        }
+    },
+    /*
+     * Section below contains Velociraptor configuration
+     */
+    "tasks": {
+        "test": "echo '/* Works! */'"
+    }
+}


### PR DESCRIPTION
Build on top of #104, this adds preliminary support for [`deno task`](https://deno.com/blog/v1.20#new-subcommand-deno-task) introduced in Deno 1.20.

It reads both `velociraptor` and `tasks` fields from `deno.json` or `deno.jsonc` and uses the latter if the former is not defined.