### PR TITLE
refactor: use standard library to parse JSONC config

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -29,4 +29,4 @@ export {
   UpdateNotifier,
 } from "https://x.nest.land/hatcher@0.10.2/mod.ts";
 export * as semver from "https://deno.land/x/semver@v1.4.0/mod.ts";
-export { default as stripJsonComments } from "https://esm.sh/strip-json-comments@4.0.0";
+export { parse as parseJson } from "https://deno.land/std@0.151.0/encoding/jsonc.ts";

--- a/deps.ts
+++ b/deps.ts
@@ -29,3 +29,4 @@ export {
   UpdateNotifier,
 } from "https://x.nest.land/hatcher@0.10.2/mod.ts";
 export * as semver from "https://deno.land/x/semver@v1.4.0/mod.ts";
+export { default as stripJsonComments } from "https://esm.sh/strip-json-comments@4.0.0";

--- a/src/load_config.ts
+++ b/src/load_config.ts
@@ -1,4 +1,4 @@
-import { existsSync, parseYaml, path } from "../deps.ts";
+import { existsSync, parseYaml, path, stripJsonComments } from "../deps.ts";
 import { ScriptsConfiguration } from "./scripts_config.ts";
 
 const CONFIG_FILE_NAMES = ["scripts", "velociraptor"];
@@ -61,12 +61,8 @@ async function parseDenoConfig(
   configPath: string,
 ): Promise<ScriptsConfiguration> {
   let content = Deno.readTextFileSync(configPath);
-  // Strips comments for .jsonc (credits to @tarkh)
-  if (/\.jsonc$/.test(configPath)) {
-    content = content.replace(
-      /\\"|"(?:\\"|[^"])*"|(\/\/.*|\/\*[\s\S]*?\*\/)/g,
-      (m, g) => g ? "" : m,
-    );
+  if (configPath.endsWith('.jsonc')) {
+    content = stripJsonComments(content);
   }
   const { velociraptor: config = {} } = JSON.parse(content);
   return config as ScriptsConfiguration;

--- a/src/load_config.ts
+++ b/src/load_config.ts
@@ -1,4 +1,4 @@
-import { existsSync, parseYaml, path, stripJsonComments } from "../deps.ts";
+import { existsSync, parseYaml, path, parseJson } from "../deps.ts";
 import { ScriptsConfiguration } from "./scripts_config.ts";
 
 const CONFIG_FILE_NAMES = ["scripts", "velociraptor"];
@@ -60,10 +60,7 @@ async function parseConfig(
 async function parseDenoConfig(
   configPath: string,
 ): Promise<ScriptsConfiguration> {
-  let content = Deno.readTextFileSync(configPath);
-  if (configPath.endsWith('.jsonc')) {
-    content = stripJsonComments(content);
-  }
-  const { velociraptor: config = {} } = JSON.parse(content);
+  const content = Deno.readTextFileSync(configPath);
+  const { velociraptor: config = {} } = parseJson(content);
   return config as ScriptsConfiguration;
 }


### PR DESCRIPTION
Switch to https://deno.land/std/encoding/jsonc.ts instead of hand-rolled regex for `.jsonc` config.